### PR TITLE
Proposal for issue priorities

### DIFF
--- a/issue-priority.md
+++ b/issue-priority.md
@@ -1,0 +1,45 @@
+## Issue priorities
+
+The priority of issues indicates when the issue should be handled and when it should be resolved.
+There are examples of issue *severity* to give an idea of how a *priority* can be assigned.
+
+Although *severity* and *priority* are often related, please keep in mind they are [different topics](http://wiki.openbravo.com/wiki/QA_Processes/Defects_Severity_Priority).
+
+### Triage (default)
+
+This issue has not been prioritized yet.
+
+### Critical
+
+Commit what you are working on and work on fixing the issue right now.
+
+**There shouldn’t be any critical issue at the end of the day.**
+
+- Production website can not run.
+- Development or testing work are blocked.
+- All users can’t use one of the features.
+
+### High
+
+Finish the task presently assigned to you, commit, then work on the issue.
+
+**There shouldn’t be any high priority issue after two days.**
+
+- Functionality or performance are severly impacted.
+- A certain type of users can’t use one of the features.
+
+### Normal
+
+Finish your story, commit, but don’t start any new story before this issue is fixed.
+
+**There should not be any normal issue at the end of the sprint.**
+
+- Functionality or performance are impacted.
+- A certain type of users can’t use one of the features, but with low impact on revenue.
+
+### Low
+
+**These issues will be handled in backlog’s order and don’t need any specific attention.**
+
+- Some colors or texts are not as they should be.
+- A problem impacts very specific users without impacting usage of the features.

--- a/issue-priority.md
+++ b/issue-priority.md
@@ -13,7 +13,7 @@ This issue has not been prioritized yet.
 
 Commit what you are working on and work on fixing the issue right now.
 
-**There shouldn’t be any critical issue at the end of the day.**
+**There should not be any unaddressed critical issues at the end of the day.**
 
 - Production website can not run.
 - Development or testing work are blocked.
@@ -23,7 +23,7 @@ Commit what you are working on and work on fixing the issue right now.
 
 Finish the task presently assigned to you, commit, then work on the issue.
 
-**There shouldn’t be any high priority issue after two days.**
+**There should not be any unaddressed high priority issue after two days.**
 
 - Functionality or performance are severly impacted.
 - A certain type of users can’t use one of the features.
@@ -32,7 +32,7 @@ Finish the task presently assigned to you, commit, then work on the issue.
 
 Finish your story, commit, but don’t start any new story before this issue is fixed.
 
-**There should not be any normal issue at the end of the sprint.**
+**There should not be any unaddressed normal issue at the end of the sprint.**
 
 - Functionality or performance are impacted.
 - A certain type of users can’t use one of the features, but with low impact on revenue.

--- a/issue-priority.md
+++ b/issue-priority.md
@@ -13,7 +13,7 @@ This issue has not been prioritized yet.
 
 Commit what you are working on and work on fixing the issue right now.
 
-**There should not be any unaddressed critical issues at the end of the day.**
+**There should not be any unaddressed critical issue after 24 hours.**
 
 - Production website can not run.
 - Development or testing work are blocked.
@@ -23,7 +23,7 @@ Commit what you are working on and work on fixing the issue right now.
 
 Finish the task presently assigned to you, commit, then work on the issue.
 
-**There should not be any unaddressed high priority issue after two days.**
+**There should not be any unaddressed high priority issue after 48 hours.**
 
 - Functionality or performance are severly impacted.
 - A certain type of users can’t use one of the features.
@@ -32,7 +32,7 @@ Finish the task presently assigned to you, commit, then work on the issue.
 
 Finish your story, commit, but don’t start any new story before this issue is fixed.
 
-**There should not be any unaddressed normal issue at the end of the sprint.**
+**There should not be any unaddressed normal issue at the end of the sprint.** <small>Unless the time to fix a bug exceeds the time left in the sprint</small>
 
 - Functionality or performance are impacted.
 - A certain type of users can’t use one of the features, but with low impact on revenue.


### PR DESCRIPTION
@imlazyone and @tjoelsson: Here is a proposal for issues priorities in Jira.

This should help the Team to know when to work on issues and Product Owners to define the priorities of issues based on severity.

I purposely limited the number of types to understand better what needs to be done and when. I would actually love to get rid of “high” or “critical”, if you have any suggestions.

~~We would need to add [this icon](https://cloud.githubusercontent.com/assets/277773/10215548/1134ae62-6855-11e5-946a-46b7b46ec3c0.png) to `/images/icons/priorities/` in Jira in order to identify the triaged issues.~~

![difference-between-priority-and-severity1](https://cloud.githubusercontent.com/assets/277773/10215716/85bfde72-6856-11e5-8f79-21a6c7abe670.jpg)

