### PR TITLE
[NES-66] Provide suggested changes to the documentation to make it mo…

### DIFF
--- a/workflow-defects.md
+++ b/workflow-defects.md
@@ -59,11 +59,21 @@ You should get familiar with it if you’re not already, **it’s awesome!**
 
 ### Deadline
 
-We may close a defect if a question does not have feedback after:
+Defects must be resolved in a timely manner based on the [issue priority guidelines][3].
+
+### No Feedback Actions
+
+There may be times that we might not get feedback from those that raise the defects, we may then follow the [issue priority guidelines][3] as to when we can close the issue. 
+
+As a summary, we may close a defect if a question does not have feedback after:
 
 - Critical: 1 day
 - High:     2 days
 - Normal:   14 days
 - Low:      14 days
 
+Conversely, it is also recommended to provide feedback before the said limits.
+
+
 [2]: http://daringfireball.net/projects/markdown/basics
+[3]: https://github.com/juwai/style-guide/blob/master/workflow-issue-priority.md

--- a/workflow-issue-priority.md
+++ b/workflow-issue-priority.md
@@ -4,7 +4,7 @@ The priority of issues indicates when the issue should be handled and when it sh
 There are examples of issue *severity* to give an idea of how a *priority* can be assigned.
 
 Defects which have un-addressed questions for more time than their priority probably have the wrong priority.
-We may **close a defect** if a question does not have a **[timely feedback](workflow-defects#deadline)**.
+We may **close a defect** if a question does not have a **[timely feedback](https://github.com/juwai/style-guide/blob/master/workflow-defects.md#no-feedback-actions)**.
 
 Although *severity* and *priority* are often related, please keep in mind they are [different topics](http://wiki.openbravo.com/wiki/QA_Processes/Defects_Severity_Priority).
 


### PR DESCRIPTION
## Summary of changes

* Moved deadline entry to No feedback actions entry.
* Changed the deadline entry to refer to the issue priority entry
* Fix issue priority broken link.

Above changes will make it more clear about deadlines and non feedbacks. 

/fyi: @agirivera: Please review.

