### PR TITLE
Use alternative syntax for control structures

### DIFF
--- a/language-template.md
+++ b/language-template.md
@@ -58,10 +58,44 @@ Use [alternative syntax for control structures](http://php.net/manual/en/control
 - Knowing what structure is closed is easier.
 - PHP and markup are better kept separated.
 
-```php
-<?php if (…) : ?>
-    <?php foreach (…) : ?>
-    <?php endforeach; ?>
-<?php endif; ?>
-```
+Examples:
 
+* NOT OK:
+
+    ```php
+    <?php if (…) { ?>
+    <!-- some markup… -->
+
+        <?php foreach (…) { ?>
+        <!-- some markup… -->
+        <?php } ?>
+
+    <!-- some markup… -->
+    <?php } ?>
+    ```
+
+    ```php
+    <?php if (…) {
+        echo '<!-- some markup… -->';
+
+        foreach (…) {
+            echo '<!-- some markup… -->';
+        }
+
+        echo '<!-- some markup… -->';
+    } ?>
+    ```
+
+* OK:
+
+    ```php
+    <?php if (…) : ?>
+    <!-- some markup… -->
+
+        <?php foreach (…) : ?>
+        <!-- some markup… -->
+        <?php endforeach; ?>
+
+    <!-- some markup… -->
+    <?php endif; ?>
+    ```

--- a/language-template.md
+++ b/language-template.md
@@ -45,6 +45,23 @@ In case of nested control structures and loops, align the markup with the closes
 
 ### PHP in templates
 
+#### Echoing values
+
 If having the logic outside the template makes code way more complicated, then:
 - ​**either**​ there is a problem in the PHP file (controller, composer…) and we can refactor the code,
 - ​**or**​ put the logic in the template, ​**and**​ leave a comment about what prevents the logic to be outside of the template.
+
+#### Writing control structures
+
+Use [alternative syntax for control structures](http://php.net/manual/en/control-structures.alternative-syntax.php):
+
+- Knowing what structure is closed is easier.
+- PHP and markup are better kept separated.
+
+```php
+<?php if (…) : ?>
+    <?php foreach (…) : ?>
+    <?php endforeach; ?>
+<?php endif; ?>
+```
+


### PR DESCRIPTION
## Summary of changes

We have this choice between two syntaxes. I believe it makes more sense to use the alternative syntax when dealing with template, for the reasons explained in the PR.

I assigned two people from the two teams as this will impact multiple products.