### PR TITLE
Additional PHP Conventions Documentations

### DIFF
--- a/language-php.md
+++ b/language-php.md
@@ -2,34 +2,51 @@
 
 We should follow best practices accepted by the community.
 As mentioned in _[php the right way][1]_, PHP-FIG, the PHP Framework Interop Group, announced PSR.
+Some of the style guides are inspired by [CodeIgniter Framework](https://github.com/bcit-ci/CodeIgniter>)
 
 We decided to follow [PSR-2].
 
 [1]: http://www.phptherightway.com/
 [PSR-2]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
 
+## Table of Contents
+
+1. [SQL Queries](#sql-queries)
+2. [Localized Texts](#localized-texts)
+3. [Debug Codes](#debug-codes)
+4. [Code Sizes](#code-sizes)
+5. [Operators](#operators)
+
 ## SQL Queries
-MySQL keywords are always capitalized: SELECT, INSERT, UPDATE, WHERE, AS, JOIN, ON, IN, etc. Break up long queries into multiple lines for legibility, preferably breaking for each clause.
+
+Although were using an ORM, there are some cases that have to do some complex sql statements and these can be done using raw MYSQL query.
+
+When doing raw MYSQL query on PHP, all statements MUST follow our current [mysql style guidelines](https://github.com/juwai/style-guide/blob/master/language-sql.md).
 
 ```
-INCORRECT:
-// keywords are lowercase and query is too long for
-// a single line (... indicates continuation of line)
-$query = $this->db->query("select foo, bar, baz, foofoo, foobar as raboof, foobaz from exp_pre_email_addresses
-...where foo != 'oof' and baz != 'zab' order by foobaz limit 5, 100");
-
-CORRECT:
-$query = $this->db->query("SELECT foo, bar, baz, foofoo, foobar AS raboof, foobaz
-				FROM exp_pre_email_addresses
-				WHERE foo != 'oof'
-				AND baz != 'zab'
-				ORDER BY foobaz
-				LIMIT 5, 100");
+$query = $this->db->query("
+    SELECT
+        `foo`,
+        `bar`,
+        `baz`,
+        `foofoo`,
+        `foobar` AS `raboof`,
+        `foobaz`
+    FROM
+        `exp_pre_email_addresses`
+    WHERE
+        `foo` != 'oof'
+        AND baz != 'zab'
+    ORDER BY `foobaz`
+    LIMIT 5 , 100
+");
 ```
 
-## Localized Text
+[Back To Top](#table-of-contents)
 
-Any text that is output in the control panel should use language variables in your lang file to allow localization.
+## Localized Texts
+
+Any text that is output in the control panel should use language variables in your lang file to allow localization. 
 
 ```
 INCORRECT:
@@ -38,38 +55,23 @@ return "Invalid Selection";
 CORRECT:
 return $this->lang->line('invalid_selection');
 ```
+[Back To Top](#table-of-contents)
 
-## Debugging Code
+## Debug Codes
 
-No debugging code can be left in place for submitted add-ons unless it is commented out, i.e. no var_dump(), print_r(), die(), and exit() calls that were used while creating the add-on, unless they are commented out.
+No debugging code MUST be left in place in any php files, i.e. no var_dump(), print_r(), die(), and exit() calls must be removed.
 
-```
-// print_r($foo);
-```
+[Back To Top](#table-of-contents)
 
-## TRUE, FALSE, and NULL
-
-TRUE, FALSE, and NULL keywords should always be fully lowercase.
-
-```
-CORRECT:
-if ($foo == true)
-$bar = false;
-function foo($bar = null)
-
-INCORRECT:
-if ($foo == TRUE)
-$bar = FALSE;
-function foo($bar = NULL)
-```
-
-## Code Size
+## Code Sizes
 
 **Methods** - Class methods that exceeds to 10 lines MUST be broken down into units that are testable. Violations of this rule usually indicate that the method is doing too much. Try to reduce the method size by creating helper methods and removing any copy/pasted code.
 
 **Classes** - Long Class files are indications that the class may be trying to do too much. Try to break it down, and reduce the size to something manageable. A class with too many methods is probably a good suspect for refactoring, in order to reduce its complexity and find a way to have more fine grained objects.
 
-**Public Members** - A large number of public methods and attributes declared in a class can indicate the class may need to be broken up as increased effort will be required to thoroughly test it.
+**Public Members** - A large number of public methods and attributes declared in a class can indicate the class may need to be broken up as increased effort will be required to thoroughly test it. 
+
+[Back To Top](#table-of-contents)
 
 ## Operators
 
@@ -80,3 +82,5 @@ $otherVariable = $variable ?: $someVariable;
 
 $otherVariable = $variable ? $variable : $someVariable;
 ```
+
+[Back To Top](#table-of-contents)

--- a/language-php.md
+++ b/language-php.md
@@ -60,7 +60,7 @@ No debugging code **MUST** be left in place in any php files, i.e. no var_dump()
 
 ## Code Sizes
 
-**Methods** - Class methods that exceeds to 10 lines **MUST** be broken down into units that are testable. Violations of this rule usually indicate that the method is doing too much. Try to reduce the method size by creating helper methods and removing any copy/pasted code.
+**Methods** - Class methods that exceed to 10 lines **MUST** be broken down into units that are testable. Violations of this rule usually indicates that the method is doing too much. Try to reduce the method size by creating helper methods and removing any copy/pasted code.
 
 **Classes** - Long Class files are indications that the class may be trying to do too much. Try to break it down, and reduce the size to something manageable. A class with too many methods is probably a good suspect for refactoring, in order to reduce its complexity and find a way to have more fine grained objects.
 

--- a/language-php.md
+++ b/language-php.md
@@ -9,22 +9,20 @@ We decided to follow [PSR-2].
 [1]: http://www.phptherightway.com/
 [PSR-2]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
 
-## Table of Contents
+---
 
-1. [SQL Queries](#sql-queries)
-2. [Localized Texts](#localized-texts)
-3. [Debug Codes](#debug-codes)
-4. [Code Sizes](#code-sizes)
-5. [Operators](#operators)
+Quick Links: [SQL Queries](#sql-queries) | [Localized Texts](#localized-texts) | [Debug Codes](#debug-codes) | [Code Sizes](#code-sizes) | [Operators](#operators)
+
+---
 
 ## SQL Queries
 
-Although were using an ORM, there are some cases that have to do some complex sql statements and these can be done using raw MYSQL query.
+Although we’re using an ORM, there are cases where complex SQL statements need raw MySQL queries.
 
-When doing raw MYSQL query on PHP, all statements MUST follow our current [mysql style guidelines](https://github.com/juwai/style-guide/blob/master/language-sql.md).
+When doing raw MySQL query on PHP, all statements MUST follow our current [mysql style guidelines](https://github.com/juwai/style-guide/blob/master/language-sql.md).
 
 ```
-$query = $this->db->query("
+$query = $this->db->query('
     SELECT
         `foo`,
         `bar`,
@@ -39,39 +37,34 @@ $query = $this->db->query("
         AND baz != 'zab'
     ORDER BY `foobaz`
     LIMIT 5 , 100
-");
+');
 ```
-
-[Back To Top](#table-of-contents)
 
 ## Localized Texts
 
-Any text that is output in the control panel should use language variables in your lang file to allow localization. 
+Any text that is output in the user interface should use language variables in your lang file to allow localization. 
 
+**Valid:**
 ```
-INCORRECT:
-return "Invalid Selection";
+return 'Invalid Selection';
+```
 
-CORRECT:
+**Invalid:**
+```
 return $this->lang->line('invalid_selection');
 ```
-[Back To Top](#table-of-contents)
 
 ## Debug Codes
 
-No debugging code MUST be left in place in any php files, i.e. no var_dump(), print_r(), die(), and exit() calls must be removed.
-
-[Back To Top](#table-of-contents)
+No debugging code **MUST** be left in place in any php files, i.e. no var_dump(), print_r(), die(), and exit() calls must be removed.
 
 ## Code Sizes
 
-**Methods** - Class methods that exceeds to 10 lines MUST be broken down into units that are testable. Violations of this rule usually indicate that the method is doing too much. Try to reduce the method size by creating helper methods and removing any copy/pasted code.
+**Methods** - Class methods that exceeds to 10 lines **MUST** be broken down into units that are testable. Violations of this rule usually indicate that the method is doing too much. Try to reduce the method size by creating helper methods and removing any copy/pasted code.
 
 **Classes** - Long Class files are indications that the class may be trying to do too much. Try to break it down, and reduce the size to something manageable. A class with too many methods is probably a good suspect for refactoring, in order to reduce its complexity and find a way to have more fine grained objects.
 
 **Public Members** - A large number of public methods and attributes declared in a class can indicate the class may need to be broken up as increased effort will be required to thoroughly test it. 
-
-[Back To Top](#table-of-contents)
 
 ## Operators
 
@@ -82,5 +75,3 @@ $otherVariable = $variable ?: $someVariable;
 
 $otherVariable = $variable ? $variable : $someVariable;
 ```
-
-[Back To Top](#table-of-contents)

--- a/language-php.md
+++ b/language-php.md
@@ -27,14 +27,30 @@ $query = $this->db->query("SELECT foo, bar, baz, foofoo, foobar AS raboof, fooba
 				LIMIT 5, 100");
 ```
 
+## Localized Text
+
+Any text that is output in the control panel should use language variables in your lang file to allow localization.
+
+```
+INCORRECT:
+return "Invalid Selection";
+
+CORRECT:
+return $this->lang->line('invalid_selection');
+```
+
 ## Debugging Code
+
 No debugging code can be left in place for submitted add-ons unless it is commented out, i.e. no var_dump(), print_r(), die(), and exit() calls that were used while creating the add-on, unless they are commented out.
+
 ```
 // print_r($foo);
 ```
 
 ## TRUE, FALSE, and NULL
+
 TRUE, FALSE, and NULL keywords should always be fully lowercase.
+
 ```
 CORRECT:
 if ($foo == true)
@@ -47,7 +63,13 @@ $bar = FALSE;
 function foo($bar = NULL)
 ```
 
+## Code Size
 
+**Methods** - Class methods that exceeds to 10 lines MUST be broken down into units that are testable. Violations of this rule usually indicate that the method is doing too much. Try to reduce the method size by creating helper methods and removing any copy/pasted code.
+
+**Classes** - Long Class files are indications that the class may be trying to do too much. Try to break it down, and reduce the size to something manageable. A class with too many methods is probably a good suspect for refactoring, in order to reduce its complexity and find a way to have more fine grained objects.
+
+**Public Members** - A large number of public methods and attributes declared in a class can indicate the class may need to be broken up as increased effort will be required to thoroughly test it.
 
 ## Operators
 

--- a/language-php.md
+++ b/language-php.md
@@ -8,6 +8,47 @@ We decided to follow [PSR-2].
 [1]: http://www.phptherightway.com/
 [PSR-2]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
 
+## SQL Queries
+MySQL keywords are always capitalized: SELECT, INSERT, UPDATE, WHERE, AS, JOIN, ON, IN, etc. Break up long queries into multiple lines for legibility, preferably breaking for each clause.
+
+```
+INCORRECT:
+// keywords are lowercase and query is too long for
+// a single line (... indicates continuation of line)
+$query = $this->db->query("select foo, bar, baz, foofoo, foobar as raboof, foobaz from exp_pre_email_addresses
+...where foo != 'oof' and baz != 'zab' order by foobaz limit 5, 100");
+
+CORRECT:
+$query = $this->db->query("SELECT foo, bar, baz, foofoo, foobar AS raboof, foobaz
+				FROM exp_pre_email_addresses
+				WHERE foo != 'oof'
+				AND baz != 'zab'
+				ORDER BY foobaz
+				LIMIT 5, 100");
+```
+
+## Debugging Code
+No debugging code can be left in place for submitted add-ons unless it is commented out, i.e. no var_dump(), print_r(), die(), and exit() calls that were used while creating the add-on, unless they are commented out.
+```
+// print_r($foo);
+```
+
+## TRUE, FALSE, and NULL
+TRUE, FALSE, and NULL keywords should always be fully lowercase.
+```
+CORRECT:
+if ($foo == true)
+$bar = false;
+function foo($bar = null)
+
+INCORRECT:
+if ($foo == TRUE)
+$bar = FALSE;
+function foo($bar = NULL)
+```
+
+
+
 ## Operators
 
 Starting from PHP 5.3, you can use `?:` to [simplify ternary operations](https://php.net/manual/en/language.operators.comparison.php#language.operators.comparison.ternary). The two following statements are the same:

--- a/language-php.md
+++ b/language-php.md
@@ -2,7 +2,7 @@
 
 We should follow best practices accepted by the community.
 As mentioned in _[php the right way][1]_, PHP-FIG, the PHP Framework Interop Group, announced PSR.
-Some of the style guides are inspired by [CodeIgniter Framework](https://github.com/bcit-ci/CodeIgniter>)
+Some of the style guides are inspired by [CodeIgniter Framework](https://www.codeigniter.com/user_guide/general/styleguide.html)
 
 We decided to follow [PSR-2].
 


### PR DESCRIPTION
## Summary of changes

- Added convention for doing mysql query line breaks for PHP
- Added convention for debug codes on PHP e.g var_dump, die and print_r
- Added convention about localized text
- Added convention about code sizes

/fyi: @piadelosreyes, @naid, @cpanganiban 