### PR TITLE
Change indentation rules for templates.

### DIFF
--- a/language-template.md
+++ b/language-template.md
@@ -8,38 +8,39 @@ for style–guides about Blade templates.
 
 ### Control Structures
 
-As decided [in this issue](https://github.com/juwai/juwai-admin/issues/394#event-437311821), the following code…
+Control structures and common code **MUST** be indented with four spaces to avoid indentation weirdness.
+
+**Invalid**
 
 ```blade
-<div>
-    @if (count($records) === 1)
-        <div>
-            …
-        </div>
-    @endif
-</div>
-```
-…should be written like so:
-
-```blade
-<div>
-    @if (count($records) === 1)
+@if (something)
+    @if (somethingElse)
     <div>
         …
     </div>
     @endif
+
+<div>
+    …
 </div>
+@endif
 ```
 
-In case of nested control structures and loops, align the markup with the closest template control:
+**Valid**
+
+
 ```blade
-<div>
-    @if (isset($userProfile)
-        @for ($i = 0; $i < 10; $i++)
-        <p>User {{ $i }} […]</p>
-        @endfor
+@if (something)
+    @if (somethingElse)
+        <div>
+            …
+        </div>
     @endif
-</div
+
+    <div>
+        …
+    </div>
+@endif
 ```
 
 


### PR DESCRIPTION
## Summary of changes

This PR follows https://github.com/juwai/style-guide/pull/51 that needed to be closed.

We have decided on a rule to align code with control structures in templates in the past, which can lead to aberrations (see following example). The current PR is a proposal to avoid that problem:

```blade
{% if event.image %}
    {% if event.url is not null %}
        <a href="{{ event.url }}" title="{{ event.title }}">
    {% endif %}

    <img
        class="img-responsive"
        srcset="{% path event.image, '1800' %} 2x"
        src="{% path event.image, '900' %}"
    >
{% endif %}
```
instead of currently:

```blade
{% if event.image %}
    {% if event.url is not null %}
    <a href="{{ event.url }}" title="{{ event.title }}">
    {% endif %}
<img
    class="img-responsive"
    srcset="{% path event.image, '1800' %} 2x"
    src="{% path event.image, '900' %}"
>
{% endif %}
```

## Notes

You can see the [final result](https://github.com/arkhi/style-guide/blob/67cc58b6ae33468a82646c35d805559d136c0964/language-template.md) which might be more readable.

/fyi: @HouCoder, @monochrome-yeh, @piadelosreyes and @naid: Please review.

/cc: @juwai/consumer-all & @juwai/industry-all @isabeljuwai might be interested in this PR as it impacts almost any template.